### PR TITLE
Allow for specifying a DNS name as an option.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,14 @@ options:
             If not provided, no certificate is used for the connection.
             If it is set to "from-unit" (the default), then the certificate is
             obtained from the unit agent file.
+    dns-name:
+        type: string
+        default: ''
+        description: |
+            The optional DNS name for Let's Encrypt, used when TLS is enabled.
+            If not empty, the TLS keys will be managed by Let's Encrypt and
+            therefore the service will run on port 443. As a consequence, the
+            port, tls-cert and tls-key charm options will be ignored.
     tls-cert:
         type: string
         default: ''

--- a/lib/charms/layer/jujushell.py
+++ b/lib/charms/layer/jujushell.py
@@ -85,7 +85,7 @@ def build_config(cfg):
         'juju-cert': juju_cert,
         'image-name': IMAGE_NAME,
         'log-level': cfg['log-level'],
-        'port': cfg['port'],
+        'port': get_port(cfg),
         'profiles': (PROFILE_DEFAULT, PROFILE_TERMSERVER),
     }
     if cfg['tls']:
@@ -98,8 +98,8 @@ def _build_tls_config(cfg):
     """Return jujushell server config related to TLS."""
     dns_name = _get_string(cfg, 'dns-name')
     if dns_name:
-        # Let's Encrypt requires port 443.
-        return {'dns-name': dns_name, 'port': 443}
+        # Let's Encrypt is used for managing certificates.
+        return {'dns-name': dns_name}
     cert, key = cfg['tls-cert'], cfg['tls-key']
     if cert != "" and key != "":
         # Keys have been provided as options.
@@ -110,6 +110,11 @@ def _build_tls_config(cfg):
     # Automatically generate a self-signed certificate.
     key, cert = _get_self_signed_cert()
     return {'tls-cert': cert, 'tls-key': key}
+
+
+def get_port(cfg):
+    """Return the port to use for exposing the jujushell service."""
+    return 443 if cfg['tls'] and _get_string(cfg, 'dns-name') else cfg['port']
 
 
 def update_lxc_quotas(cfg):

--- a/lib/charms/layer/jujushell.py
+++ b/lib/charms/layer/jujushell.py
@@ -80,12 +80,21 @@ def build_config(cfg):
     if juju_cert == 'from-unit':
         juju_cert = _get_juju_cert(agent_path())
 
+    current_port = get_port(cfg)
+    # TODO: it's very unfortunate that charm helpers do not allow to get the
+    # previous config as a dict.
+    previous_cfg = getattr(cfg, '_prev_dict', {}) or {}
+    previous_port = get_port(previous_cfg)
+    hookenv.open_port(current_port)
+    if previous_port and previous_port != current_port:
+        hookenv.close_port(previous_port)
+
     data = {
         'juju-addrs': juju_addrs.split(),
         'juju-cert': juju_cert,
         'image-name': IMAGE_NAME,
         'log-level': cfg['log-level'],
-        'port': get_port(cfg),
+        'port': current_port,
         'profiles': (PROFILE_DEFAULT, PROFILE_TERMSERVER),
     }
     if cfg['tls']:

--- a/lib/charms/layer/jujushell.py
+++ b/lib/charms/layer/jujushell.py
@@ -114,7 +114,9 @@ def _build_tls_config(cfg):
 
 def get_port(cfg):
     """Return the port to use for exposing the jujushell service."""
-    return 443 if cfg['tls'] and _get_string(cfg, 'dns-name') else cfg['port']
+    if cfg.get('tls') and _get_string(cfg, 'dns-name'):
+        return 443
+    return cfg.get('port')
 
 
 def update_lxc_quotas(cfg):

--- a/reactive/jujushell.py
+++ b/reactive/jujushell.py
@@ -149,9 +149,11 @@ def config_changed():
 def port_changed():
     config = hookenv.config()
     current = jujushell.get_port(config)
-    previous = jujushell.get_port(config.previous)
+    # TODO: it's very unfortunate that charm helpers do not allow to get the
+    # previous config as a dict.
+    previous = jujushell.get_port(config._prev_dict or {})
     hookenv.open_port(current)
-    if previous != current:
+    if previous and previous != current:
         hookenv.close_port(previous)
 
 

--- a/reactive/jujushell.py
+++ b/reactive/jujushell.py
@@ -148,14 +148,17 @@ def config_changed():
 @when('config.changed.port')
 def port_changed():
     config = hookenv.config()
-    hookenv.open_port(config['port'])
-    if config.previous('port'):
-        hookenv.close_port(config.previous('port'))
+    current = jujushell.get_port(config)
+    previous = jujushell.get_port(config.previous)
+    hookenv.open_port(current)
+    if previous != current:
+        hookenv.close_port(previous)
 
 
 @when('website.available')
 def website_available(website):
-    website.configure(port=hookenv.config('port'))
+    config = hookenv.config()
+    website.configure(port=jujushell.get_port(config))
 
 
 @when('website.available')
@@ -167,7 +170,8 @@ def website_port_changed(website):
 @when('prometheus.available')
 @when_not('prometheus.configured')
 def prometheus_available(prometheus):
-    prometheus.configure(port=hookenv.config('port'))
+    config = hookenv.config()
+    prometheus.configure(port=jujushell.get_port(config))
     set_state('prometheus.configured')
 
 

--- a/reactive/jujushell.py
+++ b/reactive/jujushell.py
@@ -145,18 +145,6 @@ def config_changed():
     set_state('jujushell.restart')
 
 
-@when('config.changed.port')
-def port_changed():
-    config = hookenv.config()
-    current = jujushell.get_port(config)
-    # TODO: it's very unfortunate that charm helpers do not allow to get the
-    # previous config as a dict.
-    previous = jujushell.get_port(config._prev_dict or {})
-    hookenv.open_port(current)
-    if previous and previous != current:
-        hookenv.close_port(previous)
-
-
 @when('website.available')
 def website_available(website):
     config = hookenv.config()

--- a/tests/test_jujushell.py
+++ b/tests/test_jujushell.py
@@ -166,7 +166,7 @@ class TestBuildConfig(unittest.TestCase):
         }
         self.assertEqual(expected_config, self.get_config())
 
-    def test_tls_provided_but_not_enabled(self):
+    def test_tls_keys_provided_but_tls_not_enabled(self):
         # Provided TLS keys are ignored when security is not enabled.
         jujushell.build_config({
             'log-level': 'debug',
@@ -181,6 +181,24 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'debug',
             'port': 80,
+            'profiles': ['default', 'termserver-limited'],
+        }
+        self.assertEqual(expected_config, self.get_config())
+
+    def test_dns_name_provided_but_tls_not_enabled(self):
+        # The provided DNS name is ignored when security is not enabled.
+        jujushell.build_config({
+            'dns-name': 'shell.example.com',
+            'log-level': 'debug',
+            'port': 8080,
+            'tls': False,
+        })
+        expected_config = {
+            'image-name': 'termserver',
+            'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
+            'juju-cert': '',
+            'log-level': 'debug',
+            'port': 8080,
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
@@ -240,6 +258,46 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
             'tls-cert': 'my cert',
             'tls-key': 'my key',
+        }
+        self.assertEqual(expected_config, self.get_config())
+
+    def test_dns_name_provided(self):
+        # The DNS name is propagated to the service when provided.
+        jujushell.build_config({
+            'dns-name': 'shell.example.com',
+            'log-level': 'debug',
+            'port': 443,
+            'tls': True,
+        })
+        expected_config = {
+            'dns-name': 'shell.example.com',
+            'image-name': 'termserver',
+            'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
+            'juju-cert': '',
+            'log-level': 'debug',
+            'port': 443,
+            'profiles': ['default', 'termserver-limited'],
+        }
+        self.assertEqual(expected_config, self.get_config())
+
+    def test_tls_keys_ignored_when_dns_name_provided(self):
+        # The TLS keys and port options are ignored when a DNS name is set.
+        jujushell.build_config({
+            'dns-name': 'example.com',
+            'log-level': 'debug',
+            'port': 80,
+            'tls': True,
+            'tls-cert': base64.b64encode(b'provided cert'),
+            'tls-key': base64.b64encode(b'provided key'),
+        })
+        expected_config = {
+            'dns-name': 'example.com',
+            'image-name': 'termserver',
+            'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
+            'juju-cert': '',
+            'log-level': 'debug',
+            'port': 443,
+            'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
 

--- a/tests/test_jujushell.py
+++ b/tests/test_jujushell.py
@@ -97,6 +97,8 @@ class TestUpdateLXCQuotas(unittest.TestCase):
         self.assertEqual(mock_call.call_count, 4)
 
 
+@patch('charmhelpers.core.hookenv.open_port')
+@patch('charmhelpers.core.hookenv.close_port')
 class TestBuildConfig(unittest.TestCase):
 
     def setUp(self):
@@ -128,7 +130,7 @@ class TestBuildConfig(unittest.TestCase):
         with open('key.pem', 'w') as keyfile:
             keyfile.write('my key')
 
-    def test_no_tls(self):
+    def test_no_tls(self, mock_close_port, mock_open_port):
         # The configuration file is created correctly without TLS.
         jujushell.build_config({
             'log-level': 'info',
@@ -144,8 +146,10 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(4247)
 
-    def test_tls_provided(self):
+    def test_tls_provided(self, mock_close_port, mock_open_port):
         # Provided TLS keys are properly used.
         jujushell.build_config({
             'log-level': 'debug',
@@ -165,8 +169,11 @@ class TestBuildConfig(unittest.TestCase):
             'tls-key': 'provided key',
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(80)
 
-    def test_tls_keys_provided_but_tls_not_enabled(self):
+    def test_tls_keys_provided_but_tls_not_enabled(
+            self, mock_close_port, mock_open_port):
         # Provided TLS keys are ignored when security is not enabled.
         jujushell.build_config({
             'log-level': 'debug',
@@ -184,8 +191,11 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(80)
 
-    def test_dns_name_provided_but_tls_not_enabled(self):
+    def test_dns_name_provided_but_tls_not_enabled(
+            self, mock_close_port, mock_open_port):
         # The provided DNS name is ignored when security is not enabled.
         jujushell.build_config({
             'dns-name': 'shell.example.com',
@@ -202,8 +212,10 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(8080)
 
-    def test_tls_generated(self):
+    def test_tls_generated(self, mock_close_port, mock_open_port):
         # TLS keys are generated if not provided.
         self.make_cert()
         with patch('jujushell.call') as mock_call:
@@ -237,8 +249,11 @@ class TestBuildConfig(unittest.TestCase):
             '-subj', '/C=/ST=/L=/O=/OU=/CN=0.0.0.0')
         # Key files has been removed.
         self.assertEqual(['files'], os.listdir('.'))
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(4247)
 
-    def test_tls_generated_when_key_is_missing(self):
+    def test_tls_generated_when_key_is_missing(
+            self, mock_close_port, mock_open_port):
         # TLS keys are generated if only one key is provided, not both.
         self.make_cert()
         with patch('jujushell.call'):
@@ -260,8 +275,10 @@ class TestBuildConfig(unittest.TestCase):
             'tls-key': 'my key',
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(4247)
 
-    def test_dns_name_provided(self):
+    def test_dns_name_provided(self, mock_close_port, mock_open_port):
         # The DNS name is propagated to the service when provided.
         jujushell.build_config({
             'dns-name': 'shell.example.com',
@@ -279,8 +296,11 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(443)
 
-    def test_tls_keys_ignored_when_dns_name_provided(self):
+    def test_tls_keys_ignored_when_dns_name_provided(
+            self, mock_close_port, mock_open_port):
         # The TLS keys and port options are ignored when a DNS name is set.
         jujushell.build_config({
             'dns-name': 'example.com',
@@ -300,8 +320,10 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(443)
 
-    def test_provided_juju_cert(self):
+    def test_provided_juju_cert(self, mock_close_port, mock_open_port):
         # The configuration file is created with the provided Juju certificate.
         jujushell.build_config({
             'log-level': 'info',
@@ -318,8 +340,10 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(4247)
 
-    def test_juju_cert_from_agent_file(self):
+    def test_juju_cert_from_agent_file(self, mock_close_port, mock_open_port):
         # A Juju certificate can be retrieved from the agent file in the unit.
         # Make agent file live in the temp dir.
         agent = os.path.join(os.environ['CHARM_DIR'], '..', 'agent.conf')
@@ -340,8 +364,10 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(4247)
 
-    def test_provided_juju_addresses(self):
+    def test_provided_juju_addresses(self, mock_close_port, mock_open_port):
         # Juju addresses can be provided via the configuration.
         jujushell.build_config({
             'juju-addrs': '1.2.3.4/provided 4.3.2.1/provided',
@@ -358,8 +384,28 @@ class TestBuildConfig(unittest.TestCase):
             'profiles': ['default', 'termserver-limited'],
         }
         self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(4247)
 
-    def test_error_no_juju_addresses(self):
+    def test_previous_port_closed(self, mock_close_port, mock_open_port):
+        # When changing between ports, the previous one is properly closed.
+        Config = type('Config', (dict,), {'_prev_dict': None})
+        config = Config({
+            'dns-name': 'shell.example.com',
+            'log-level': 'debug',
+            'port': 80,
+            'tls': True,
+        })
+        config._prev_dict = {
+            'log-level': 'debug',
+            'port': 80,
+            'tls': True,
+        }
+        jujushell.build_config(config)
+        mock_close_port.assert_called_once_with(80)
+        mock_open_port.assert_called_once_with(443)
+
+    def test_error_no_juju_addresses(self, mock_close_port, mock_open_port):
         # A ValueError is raised if no Juju addresses can be retrieved.
         os.environ['JUJU_API_ADDRESSES'] = ''
         with self.assertRaises(ValueError) as ctx:
@@ -369,6 +415,8 @@ class TestBuildConfig(unittest.TestCase):
                 'tls': False,
             })
         self.assertEqual('could not find API addresses', str(ctx.exception))
+        self.assertEqual(0, mock_close_port.call_count)
+        self.assertEqual(0, mock_open_port.call_count)
 
 
 class TestGetPort(unittest.TestCase):

--- a/tests/test_jujushell.py
+++ b/tests/test_jujushell.py
@@ -371,6 +371,37 @@ class TestBuildConfig(unittest.TestCase):
         self.assertEqual('could not find API addresses', str(ctx.exception))
 
 
+class TestGetPort(unittest.TestCase):
+
+    def test_with_dns_name(self):
+        # Port 443 is returned if a DNS name has been provided.
+        port = jujushell.get_port({
+            'dns-name': 'example.com', 'port': 4247, 'tls': True})
+        self.assertEqual(443, port)
+
+    def test_with_invalid_dns_name(self):
+        # The DNS name is ignored if not valid.
+        port = jujushell.get_port({'dns-name': ' ', 'port': 4247, 'tls': True})
+        self.assertEqual(4247, port)
+
+    def test_without_dns_name(self):
+        # The port specified in the config is returned if no DNS name is set.
+        port = jujushell.get_port({'port': 8000, 'tls': True})
+        self.assertEqual(8000, port)
+
+    def test_without_dns_name_no_tls(self):
+        # The port specified in the config is returned if security is disabled.
+        port = jujushell.get_port({'port': 8080, 'tls': False})
+        self.assertEqual(8080, port)
+
+    def test_with_dns_name_no_tls(self):
+        # The port specified in the config is returned if security is disabled,
+        # even when a DNS name has been provided.
+        port = jujushell.get_port({
+            'dns-name': 'example.com', 'port': 4247, 'tls': False})
+        self.assertEqual(4247, port)
+
+
 @patch('charmhelpers.core.hookenv.log')
 class TestSaveResource(unittest.TestCase):
 


### PR DESCRIPTION
The option is then propagated to the jujushell in order to enable handling certificates with Let's Encrypt.