### PR TITLE
Add the session-timeout charm option.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -76,3 +76,10 @@ options:
             service. An empty list means that all users who can authenticate
             against the controller are allowed. For external users, names must
             include the "@external" suffix.
+    session-timeout:
+        type: int
+        default: 0
+        description: |
+            The number of minutes of inactivity to wait before expiring a
+            session and stopping user container instances. A zero value means
+            that the session never expires.

--- a/lib/charms/layer/jujushell.py
+++ b/lib/charms/layer/jujushell.py
@@ -99,6 +99,7 @@ def build_config(cfg):
         'log-level': cfg['log-level'],
         'port': current_ports[0],
         'profiles': (PROFILE_DEFAULT, PROFILE_TERMSERVER),
+        'session-timeout': cfg.get('session-timeout', 0),
     }
     if cfg['tls']:
         data.update(_build_tls_config(cfg))

--- a/tests/test_jujushell.py
+++ b/tests/test_jujushell.py
@@ -156,6 +156,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'info',
             'port': 4247,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)
@@ -178,6 +179,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'debug',
             'port': 80,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
             'tls-cert': 'provided cert',
             'tls-key': 'provided key',
         }
@@ -203,6 +205,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'debug',
             'port': 80,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)
@@ -225,6 +228,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'debug',
             'port': 8080,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)
@@ -249,6 +253,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'trace',
             'port': 4247,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
             'tls-cert': 'my cert',
             'tls-key': 'my key',
         }
@@ -288,6 +293,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'trace',
             'port': 4247,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
             'tls-cert': 'my cert',
             'tls-key': 'my key',
         }
@@ -312,6 +318,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'debug',
             'port': 443,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)
@@ -338,6 +345,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'debug',
             'port': 443,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)
@@ -360,6 +368,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'info',
             'port': 4247,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)
@@ -385,6 +394,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'info',
             'port': 4247,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)
@@ -406,6 +416,7 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'info',
             'port': 4247,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)
@@ -498,6 +509,29 @@ class TestBuildConfig(unittest.TestCase):
             'log-level': 'info',
             'port': 4247,
             'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 0,
+        }
+        self.assertEqual(expected_config, self.get_config())
+        self.assertEqual(0, mock_close_port.call_count)
+        mock_open_port.assert_called_once_with(4247)
+
+    def test_session_timeout(self, mock_close_port, mock_open_port):
+        # The session timeout value is properly generated.
+        jujushell.build_config({
+            'log-level': 'info',
+            'port': 4247,
+            'session-timeout': 42,
+            'tls': False,
+        })
+        expected_config = {
+            'allowed-users': [],
+            'image-name': 'termserver',
+            'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
+            'juju-cert': '',
+            'log-level': 'info',
+            'port': 4247,
+            'profiles': ['default', 'termserver-limited'],
+            'session-timeout': 42,
         }
         self.assertEqual(expected_config, self.get_config())
         self.assertEqual(0, mock_close_port.call_count)


### PR DESCRIPTION
The new option allows for controlling session expiration due to user inactivity.
The functionality is introduced in the PR at https://github.com/juju/jujushell/pull/10