### PR TITLE
Fix quotas, pylxd and remove snapd workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEBDEPS=python3-virtualenv
+DEBDEPS=build-essential python3-dev python3-virtualenv
 SNAPDEPS=charm
 VENVDEPS=charmhelpers charms.reactive coverage flake8 pylxd pyyaml
 

--- a/layer.yaml
+++ b/layer.yaml
@@ -10,4 +10,3 @@ options:
         packages:
             - python-yaml
             - python3
-            - python3-pylxd

--- a/lib/charms/layer/jujushell.py
+++ b/lib/charms/layer/jujushell.py
@@ -15,7 +15,6 @@ from charmhelpers.core import (
 from charms.reactive import (
     set_flag,
 )
-import pylxd
 import yaml
 
 
@@ -143,6 +142,7 @@ def get_ports(cfg):
 
 def update_lxc_quotas(cfg):
     """Update the default profile to include resource limits from config."""
+    hookenv.status_set('maintenance', 'updating LXC quotas')
     call(LXC, 'profile', 'set', 'default', 'limits.cpu',
          _get_string(cfg, 'lxc-quota-cpu-cores'))
     call(LXC, 'profile', 'set', 'default',
@@ -262,6 +262,7 @@ def import_lxd_image(name, path):
 
 def _lxd_client():
     """Get a client connection to the LXD server."""
+    import pylxd  # Imported here because pylxd is not immediately available.
     return pylxd.client.Client('http+unix://{}'.format(
         parse.quote(_LXD_SOCKET, safe='')))
 

--- a/lib/charms/layer/jujushell.py
+++ b/lib/charms/layer/jujushell.py
@@ -21,6 +21,7 @@ import yaml
 
 # Define the LXD image name and profiles to use when launching instances.
 IMAGE_NAME = 'termserver'
+LXC = '/snap/bin/lxc'
 PROFILE_DEFAULT, PROFILE_TERMSERVER = 'default', 'termserver-limited'
 
 
@@ -142,19 +143,14 @@ def get_ports(cfg):
 
 def update_lxc_quotas(cfg):
     """Update the default profile to include resource limits from config."""
-    # TODO(frankban): workaround for bug fixed at
-    # <https://github.com/snapcore/snapd/pull/4981>.
-    call('snap', 'connect', 'lxd:lxd-support', 'core:lxd-support')
-    call('systemctl', 'restart', 'snap.lxd.daemon')
-    # Back to normal procedure.
-    call('/snap/bin/lxc', 'profile', 'set', 'default', 'limits.cpu',
+    call(LXC, 'profile', 'set', 'default', 'limits.cpu',
          _get_string(cfg, 'lxc-quota-cpu-cores'))
-    call('/snap/bin/lxc', 'profile', 'set', 'default',
+    call(LXC, 'profile', 'set', 'default',
          'limits.cpu.allowance',
          _get_string(cfg, 'lxc-quota-cpu-allowance'))
-    call('/snap/bin/lxc', 'profile', 'set', 'default', 'limits.memory',
+    call(LXC, 'profile', 'set', 'default', 'limits.memory',
          _get_string(cfg, 'lxc-quota-ram'))
-    call('/snap/bin/lxc', 'profile', 'set', 'default', 'limits.processes',
+    call(LXC, 'profile', 'set', 'default', 'limits.processes',
          _get_string(cfg, 'lxc-quota-processes'))
 
 

--- a/reactive/jujushell.py
+++ b/reactive/jujushell.py
@@ -24,6 +24,13 @@ from charms.reactive import (
 
 @hook('install')
 def install():
+    # pylxd is installed here manually rather than using the apt layer or the
+    # wheelhouse. The latter cannot be used as the package relies on C modules
+    # to be compiled. The apt package is out of date, as we need the fix at
+    # https://github.com/lxc/pylxd/issues/232 in xenial.
+    # TODO(frankban) We can remove this in favor of installing via apt when
+    # xenial is updated with the fixed package.
+    jujushell.call('pip', 'install', 'pylxd==2.2.6')
     set_flag('jujushell.install')
 
 
@@ -104,6 +111,7 @@ def setup_lxd():
     hookenv.status_set('maintenance', 'configuring lxd')
     host.add_user_to_group('ubuntu', 'lxd')
     jujushell.setup_lxd()
+    jujushell.update_lxc_quotas(hookenv.config())
 
 
 @when('jujushell.lxd.configured')
@@ -151,7 +159,6 @@ def config_changed():
     config = hookenv.config()
     jujushell.build_config(config)
     if is_flag_set('jujushell.lxd.configured'):
-        hookenv.status_set('maintenance', 'updating LXC quotas')
         jujushell.update_lxc_quotas(config)
         clear_flag('jujushell.lxd.image.imported.termserver')
     set_flag('jujushell.restart')

--- a/reactive/jujushell.py
+++ b/reactive/jujushell.py
@@ -150,8 +150,8 @@ def stop_service():
 def config_changed():
     config = hookenv.config()
     jujushell.build_config(config)
-
-    if is_flag_set('snap.installed.lxd'):
+    if is_flag_set('jujushell.lxd.configured'):
+        hookenv.status_set('maintenance', 'updating LXC quotas')
         jujushell.update_lxc_quotas(config)
         clear_flag('jujushell.lxd.image.imported.termserver')
     set_flag('jujushell.restart')

--- a/tests/test_jujushell.py
+++ b/tests/test_jujushell.py
@@ -85,9 +85,6 @@ class TestUpdateLXCQuotas(unittest.TestCase):
         with patch('jujushell.call') as mock_call:
             jujushell.update_lxc_quotas(cfg)
         expected_calls = [
-            # TODO(frankban): remove the first two calls when snapd is fixed.
-            call('snap', 'connect', 'lxd:lxd-support', 'core:lxd-support'),
-            call('systemctl', 'restart', 'snap.lxd.daemon'),
             call('/snap/bin/lxc', 'profile', 'set', 'default',
                  'limits.cpu', '1'),
             call('/snap/bin/lxc', 'profile', 'set', 'default',

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,3 @@
-firestealer
+firestealer==0.4.1
 setuptools_scm # Required to avoid python-dateutil errors.
+pylxd==2.2.6

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,2 @@
 firestealer==0.4.1
 setuptools_scm # Required to avoid python-dateutil errors.
-pylxd==2.2.6


### PR DESCRIPTION
This branch include 3 minor fixes:
- do not try to set lxd quotas before lxd is completely configured: this was causing an install hook error that was only recovered thanks to the autoretry hooks functionality;
- do not use out of date pylxd debian package as it is affected by a bug that caused an install hook error; pip install latest version instead;
- remove the snapd workaround from yesterday.
