### PR TITLE
Allow for deploying jujushell on bionic

### DIFF
--- a/lib/charms/layer/jujushell.py
+++ b/lib/charms/layer/jujushell.py
@@ -178,7 +178,7 @@ def _get_self_signed_cert():
          '-out', 'cert.pem',
          '-days', '365',
          '-nodes',
-         '-subj', '/C=/ST=/L=/O=/OU=/CN=0.0.0.0')
+         '-subj', '/C=GB/ST=London/L=London/O=Canonical/OU=JAAS/CN=0.0.0.0')
     with open('key.pem') as keyfile:
         key = keyfile.read()
     with open('cert.pem') as certfile:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,6 @@
 name: jujushell
 series:
+    - bionic
     - xenial
 summary: allow shell access to one's juju model through a web interface
 maintainer: Madison Scott-Clary <madison.scott-clary@canonical.com>

--- a/tests/test_jujushell.py
+++ b/tests/test_jujushell.py
@@ -273,7 +273,7 @@ class TestBuildConfig(unittest.TestCase):
             '-out', 'cert.pem',
             '-days', '365',
             '-nodes',
-            '-subj', '/C=/ST=/L=/O=/OU=/CN=0.0.0.0')
+            '-subj', '/C=GB/ST=London/L=London/O=Canonical/OU=JAAS/CN=0.0.0.0')
         # Key files has been removed.
         self.assertEqual(['files'], os.listdir('.'))
         self.assertEqual(0, mock_close_port.call_count)


### PR DESCRIPTION
The only change required is required to a newer version of openssl requiring some metadata not to be empty.