### PR TITLE
Support TLS alpn challenge and fix quota races

### DIFF
--- a/lib/charms/layer/jujushell.py
+++ b/lib/charms/layer/jujushell.py
@@ -134,8 +134,8 @@ def get_ports(cfg):
     """
     if cfg.get('tls') and _get_string(cfg, 'dns-name'):
         # The jujushell is using Let's Encrypt, and therefore it needs port 443
-        # (for the service) and port 80 (for the HTTP challenge) to be open.
-        return (443, 80)
+        # to be open.
+        return (443,)
     port = cfg.get('port')
     return (port,) if port else ()
 

--- a/reactive/jujushell.py
+++ b/reactive/jujushell.py
@@ -111,7 +111,6 @@ def setup_lxd():
     hookenv.status_set('maintenance', 'configuring lxd')
     host.add_user_to_group('ubuntu', 'lxd')
     jujushell.setup_lxd()
-    jujushell.update_lxc_quotas(hookenv.config())
 
 
 @when('jujushell.lxd.configured')
@@ -159,7 +158,11 @@ def config_changed():
     config = hookenv.config()
     jujushell.build_config(config)
     if is_flag_set('jujushell.lxd.configured'):
-        jujushell.update_lxc_quotas(config)
+        try:
+            jujushell.update_lxc_quotas(config)
+        except Exception:
+            # Setting quotas can fail while lxd snap is being upgraded.
+            pass
         clear_flag('jujushell.lxd.image.imported.termserver')
     set_flag('jujushell.restart')
 


### PR DESCRIPTION
This branch includes two improvements:
- support the new Let's Encrypt challenge that does not require port 80 to be open;
- fix a race condition causing a charm error while trying to set quotas while snap was installing lxd.

This branch can only be used with the jujushell service at https://github.com/juju/jujushell/pull/16