### PR TITLE
Do not install lxd, use the existing one on the machine 

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,7 +1,6 @@
 includes:
     - 'layer:basic'
     - 'layer:apt'
-    - 'layer:snap'
     - 'interface:http'
     - 'interface:prometheus'
 repo: https://github.com/juju/jujushell-charm

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,6 @@
 name: jujushell
 series:
     - bionic
-    - xenial
 summary: allow shell access to one's juju model through a web interface
 maintainer: Madison Scott-Clary <madison.scott-clary@canonical.com>
 description: |

--- a/reactive/jujushell.py
+++ b/reactive/jujushell.py
@@ -7,10 +7,7 @@ from charmhelpers.core import (
     host,
 )
 from charms import apt
-from charms.layer import (
-    jujushell,
-    snap,
-)
+from charms.layer import jujushell
 from charms.reactive import (
     is_flag_set,
     hook,
@@ -53,14 +50,6 @@ def stop():
 
 
 @when('jujushell.install')
-@when_not('snap.installed.lxd')
-def install_lxd():
-    hookenv.status_set('maintenance', 'installing lxd')
-    snap.install('lxd')
-
-
-@when('jujushell.install')
-@when('snap.installed.lxd')
 @when_not('apt.installed.zfsutils-linux')
 def install_zfsutils():
     hookenv.status_set('maintenance', 'installing zfsutils-linux')
@@ -104,7 +93,7 @@ def install_service():
     jujushell.install_service()
 
 
-@when('snap.installed.lxd')
+@when('jujushell.install')
 @when('apt.installed.zfsutils-linux')
 @only_once
 def setup_lxd():
@@ -158,11 +147,7 @@ def config_changed():
     config = hookenv.config()
     jujushell.build_config(config)
     if is_flag_set('jujushell.lxd.configured'):
-        try:
-            jujushell.update_lxc_quotas(config)
-        except Exception:
-            # Setting quotas can fail while lxd snap is being upgraded.
-            pass
+        jujushell.update_lxc_quotas(config)
         clear_flag('jujushell.lxd.image.imported.termserver')
     set_flag('jujushell.restart')
 

--- a/tests/test_jujushell.py
+++ b/tests/test_jujushell.py
@@ -111,6 +111,7 @@ class TestTermserverPath(unittest.TestCase):
 
 @patch('charmhelpers.core.hookenv.open_port')
 @patch('charmhelpers.core.hookenv.close_port')
+@patch('os.path.exists', lambda _: True)
 class TestBuildConfig(unittest.TestCase):
 
     def setUp(self):
@@ -155,6 +156,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'info',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -182,6 +184,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'debug',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 80,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -212,6 +215,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'debug',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 80,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -239,6 +243,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'debug',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 8080,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -268,6 +273,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'trace',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -312,6 +318,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'trace',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -341,6 +348,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'debug',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 443,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -371,6 +379,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'debug',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 443,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -397,6 +406,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': 'provided cert',
             'log-level': 'info',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -427,6 +437,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': 'agent cert',
             'log-level': 'info',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -453,6 +464,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4/provided', '4.3.2.1/provided'],
             'juju-cert': '',
             'log-level': 'info',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -510,6 +522,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'info',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -536,6 +549,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'info',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,
@@ -562,6 +576,7 @@ class TestBuildConfig(unittest.TestCase):
             'juju-addrs': ['1.2.3.4:17070', '4.3.2.1:17070'],
             'juju-cert': '',
             'log-level': 'info',
+            'lxd-socket-path': '/var/lib/lxd/unix.socket',
             'port': 4247,
             'profiles': [
                 jujushell.PROFILE_TERMSERVER,

--- a/tests/test_jujushell.py
+++ b/tests/test_jujushell.py
@@ -85,13 +85,13 @@ class TestUpdateLXCQuotas(unittest.TestCase):
         with patch('jujushell.call') as mock_call:
             jujushell.update_lxc_quotas(cfg)
         expected_calls = [
-            call('/snap/bin/lxc', 'profile', 'set', 'default',
+            call(jujushell.LXC, 'profile', 'set', jujushell.PROFILE_TERMSERVER,
                  'limits.cpu', '1'),
-            call('/snap/bin/lxc', 'profile', 'set', 'default',
+            call(jujushell.LXC, 'profile', 'set', jujushell.PROFILE_TERMSERVER,
                  'limits.cpu.allowance', '100%'),
-            call('/snap/bin/lxc', 'profile', 'set', 'default',
+            call(jujushell.LXC, 'profile', 'set', jujushell.PROFILE_TERMSERVER,
                  'limits.memory', '256MB'),
-            call('/snap/bin/lxc', 'profile', 'set', 'default',
+            call(jujushell.LXC, 'profile', 'set', jujushell.PROFILE_TERMSERVER,
                  'limits.processes', '100'),
         ]
         mock_call.assert_has_calls(expected_calls)
@@ -156,7 +156,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'info',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -180,7 +183,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'debug',
             'port': 80,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'tls-cert': 'provided cert',
             'tls-key': 'provided key',
@@ -207,7 +213,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'debug',
             'port': 80,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -231,7 +240,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'debug',
             'port': 8080,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -257,7 +269,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'trace',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'tls-cert': 'my cert',
             'tls-key': 'my key',
@@ -298,7 +313,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'trace',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'tls-cert': 'my cert',
             'tls-key': 'my key',
@@ -324,7 +342,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'debug',
             'port': 443,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -351,7 +372,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'debug',
             'port': 443,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -374,7 +398,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': 'provided cert',
             'log-level': 'info',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -401,7 +428,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': 'agent cert',
             'log-level': 'info',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -424,7 +454,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'info',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -478,7 +511,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'info',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': '',
         }
@@ -501,7 +537,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'info',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 42,
             'welcome-message': '',
         }
@@ -524,7 +563,10 @@ class TestBuildConfig(unittest.TestCase):
             'juju-cert': '',
             'log-level': 'info',
             'port': 4247,
-            'profiles': ['default', 'termserver-limited'],
+            'profiles': [
+                jujushell.PROFILE_TERMSERVER,
+                jujushell.PROFILE_TERMSERVER_LIMITED,
+            ],
             'session-timeout': 0,
             'welcome-message': 'these are\nthe voyages',
         }


### PR DESCRIPTION
It's not possible to use snapped LXD and the deb one together anymore, as the snap propose migrating. Also considering that sooner or later Juju will install snaps on its instances, the current strategy of jujushell using the snap LXD instance and Juju using the pre-installed deb one is no longer an option. Therefore,we now use whatever is already present in the machine, set up by Juju (or cloud-init). We create other profiles, termserver and termserver-limited, to avoid name clashes. We also drop support for xenial as it does not include LXD 3.x that we need as jujushell uses the new LXD API.
So from now on, jujushell is bionic only.